### PR TITLE
Updated getTermList to stop Fatal Error

### DIFF
--- a/model/Base.php
+++ b/model/Base.php
@@ -269,6 +269,7 @@ class Base
 
         if ($Terms = $this->modx->getCollectionGraph('PageTerm','{"Page":{}}',$c)) {
             foreach ($Terms as $t) {
+                if(!$t->Page) continue;
                 $out .= '<tr>
                     <td><a href="'.MODX_MANAGER_URL.'?a=resource/update&id='.$t->get('page_id') .'">'.$t->Page->get('pagetitle').' ('.$t->get('page_id').')</a></td>
                     <td>'.$t->Page->get('alias').'</td>


### PR DESCRIPTION
There is an edge case where if a resource has a term linked and then the page is removed (but not the link) this look causes a fatal error due to `$t->Page` being null.

I've just added a sanity check to continue quietly if this happens
